### PR TITLE
Update to version 2 of quick-error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "AltSysrq/rusty-fork" }
 
 [dependencies]
 fnv = "1.0"
-quick-error = "1.2"
+quick-error = "2.0"
 tempfile = "3.0"
 wait-timeout = { version = "0.2", optional = true }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,7 +52,7 @@ quick_error! {
         /// Spawning a subprocess failed.
         SpawnError(err: io::Error) {
             from()
-            cause(err)
+            source(err)
             display("Spawn failed: {}", err)
         }
     }


### PR DESCRIPTION
This just updates `quick-error` to version 2. This did involve switching `cause` over to `source` and removing `description` since both were deprecated since rust 1.42.0.