### PR TITLE
Update quick-error to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "AltSysrq/rusty-fork" }
 
 [dependencies]
 fnv = "1.0"
-quick-error = "1.2"
+quick-error = "2.0"
 tempfile = "3.0"
 wait-timeout = { version = "0.2", optional = true }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,7 +52,7 @@ quick_error! {
         /// Spawning a subprocess failed.
         SpawnError(err: io::Error) {
             from()
-            cause(err)
+            source(err)
             display("Spawn failed: {}", err)
         }
     }


### PR DESCRIPTION
Dedupes a crate in my dep tree 🙃

As far as I can tell, the only difference between quick-error 1.x and 2.x is that 2.x switched from generating the deprecated `Error::cause` method to `Error::source`
