### PR TITLE
Add optional return type to rusty_test functions

### DIFF
--- a/src/fork.rs
+++ b/src/fork.rs
@@ -79,7 +79,7 @@ const OCCURS_TERM_LENGTH: usize = 17; /* ':' plus 16 hexits */
 /// executable.
 ///
 /// Panics if any argument to the current process is not valid UTF-8.
-pub fn fork<ID, MODIFIER, PARENT, CHILD, R>(
+pub fn fork<ID, MODIFIER, PARENT, CHILD, R, T>(
     test_name: &str,
     fork_id: ID,
     process_modifier: MODIFIER,
@@ -89,7 +89,7 @@ where
     ID : Hash,
     MODIFIER : FnOnce (&mut process::Command),
     PARENT : FnOnce (&mut ChildWrapper, &mut fs::File) -> R,
-    CHILD : FnOnce ()
+    CHILD : FnOnce () -> T
 {
     let fork_id = id_str(fork_id);
 
@@ -108,10 +108,10 @@ where
         .map(|_| return_value.unwrap())
 }
 
-fn fork_impl(test_name: &str, fork_id: String,
+fn fork_impl<T>(test_name: &str, fork_id: String,
              process_modifier: &mut dyn FnMut (&mut process::Command),
              in_parent: &mut dyn FnMut (&mut ChildWrapper, &mut fs::File),
-             in_child: &mut dyn FnMut ()) -> Result<()> {
+             in_child: &mut dyn FnMut () -> T) -> Result<()> {
     let mut occurs = env::var(OCCURS_ENV).unwrap_or_else(|_| String::new());
     if occurs.contains(&fork_id) {
         match panic::catch_unwind(panic::AssertUnwindSafe(in_child)) {

--- a/src/fork_test.rs
+++ b/src/fork_test.rs
@@ -72,14 +72,14 @@ macro_rules! rusty_fork_test {
     (#![rusty_fork(timeout_ms = $timeout:expr)]
      $(
          $(#[$meta:meta])*
-         fn $test_name:ident() $body:block
+         fn $test_name:ident() $( -> $test_return:ty )? $body:block
     )*) => { $(
         $(#[$meta])*
         fn $test_name() {
             // Eagerly convert everything to function pointers so that all
             // tests use the same instantiation of `fork`.
-            fn body_fn() $body
-            let body: fn () = body_fn;
+            fn body_fn() $( -> $test_return )? $body
+            let body: fn () $( -> $test_return )? = body_fn;
 
             fn supervise_fn(child: &mut $crate::ChildWrapper,
                             _file: &mut ::std::fs::File) {
@@ -99,12 +99,12 @@ macro_rules! rusty_fork_test {
 
     ($(
          $(#[$meta:meta])*
-         fn $test_name:ident() $body:block
+         fn $test_name:ident() $( -> $test_return:ty )? $body:block
     )*) => {
         rusty_fork_test! {
             #![rusty_fork(timeout_ms = 0)]
 
-            $($(#[$meta])* fn $test_name() $body)*
+            $($(#[$meta])* fn $test_name() $( -> $test_return )?  $body)*
         }
     };
 }
@@ -173,6 +173,9 @@ mod test {
     rusty_fork_test! {
         #[test]
         fn trivial() { }
+
+         #[test]
+        fn trivial_with_return() -> Result<(), &'static str> { Ok(()) }
 
         #[test]
         #[should_panic]


### PR DESCRIPTION
This PR allow to use `rusty_fork_test!` tests having a return type :
```rust
    rusty_fork_test! {
        #[test]
        fn trivial() { }

         #[test]
        fn trivial_with_return() -> Result<(), &'static str> { Ok(()) }
    }
```